### PR TITLE
Update sources.bib with corrected format

### DIFF
--- a/kinbank/raw/sources.bib
+++ b/kinbank/raw/sources.bib
@@ -12339,3 +12339,80 @@
     volume = {2},
     year = {1963}
 }
+
+@article{thompson_ache_2019,
+    Author = {Thompson, Warren},
+    Journal = {Boletim do Museu Paraense Emílio Goeldi, Ciências Humanas},
+    Keywords = {JC, TP40, ache1246, kinbank},
+    Language = {en},
+    Number = {1},
+    Pages = {131--145},
+    Title = {Kin on the Wing: patterns in residence, mobility, and alliance for Ache hunter-gatherers},
+    Volume = {14},
+    Year = {2019},
+    sourceid = {TP40}
+}
+
+
+@article{ohagan_omagua_2019,
+    Author = {O’Hagan, Zachary},
+    Journal = {Boletim do Museu Paraense Emílio Goeldi, Ciências Humanas},
+    Keywords = {JC, TP40, omag1247, kinbank},
+    Language = {en},
+    Number = {1},
+    Pages = {65--78},
+    Title = {Restructuring of Proto-Omagua-Kukama Kin Terms},
+    Volume = {14},
+    Year = {2019},
+    sourceid = {TP41}
+}
+
+
+@article{valentino_katawian_2019,
+    Author = {Valentino, Leonor},
+    Journal = {Boletim do Museu Paraense Emílio Goeldi, Ciências Humanas},
+    Keywords = {JC, TP40, kata1269, kinbank},
+    Language = {pt},
+    Number = {1},
+    Pages = {147--166},
+    Title = {Notas Sobre Duas Terminologias de Parentesco Caribe No Norte Amazônico: Katwena-Tunayana E Waiwai},
+    Volume = {14},
+    Year = {2019},
+    sourceid = {TP42}
+}
+
+
+@article{ferreira-alve_ikpeng_2019,
+    Author = {Ferreira-Alves, Ana Carolina and Chagas, Angela Fabíola Alves and BarbosaII, Leonard Jéferson Grala},
+    Journal = {Boletim do Museu Paraense Emílio Goeldi, Ciências Humanas},
+    Keywords = {JC, TP40, ikpe1245, kinbank},
+    Language = {pt},
+    Number = {1},
+    Pages = {101--119},
+    Title = {Termos de Parentesco: Primeiras Reconstruções Em Proto-Arara-Ikpeng},
+    Volume = {14},
+    Year = {2019},
+    sourceid = {TP43}
+}
+
+
+@article{nogueira_tuparí_2019,
+    Author = {Nogueira, Antônia Fernanda Souza and GalucioIII, Ana Vilacy and Soares-Pinto, Nicole and Singerman, Adam Roth},
+    Journal = {Boletim do Museu Paraense Emílio Goeldi, Ciências Humanas},
+    Keywords = {JC, TP40, tupa1250, kinbank},
+    Language = {pt},
+    Number = {1},
+    Pages = {33-64},
+    Title = {Termos de Parentesco Nas Línguas Tuparí (Família Tupí)},
+    Volume = {14},
+    Year = {2019},
+    sourceid = {TP45}
+}
+
+
+@book{Rivière _1969,
+    author = {Rivière, Peter},
+    publisher = {Oxford},
+    title = {Marriage among the Trio: A Principle of Social Organisation},
+    year = {1969}
+}


### PR DESCRIPTION
Added bibliographical sources for target Tupian and Cariban data files, currently under review in Joshua Birchall's repository fork before submitting to main hub kinbank / goeldi.

Fixed 'et. al' in Nogueria and Ferreria-Alves articles, citing all authors in correct format. - AB